### PR TITLE
Fix black screen caused by Unicode locale extensions

### DIFF
--- a/src/STS2Mobile/Patches/PlatformPatches.cs
+++ b/src/STS2Mobile/Patches/PlatformPatches.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Globalization;
+using System.Reflection;
 using System.Threading.Tasks;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Debug;
@@ -50,6 +53,11 @@ public static class PlatformPatches
             "Initialize",
             prefix: PatchHelper.Method(typeof(PlatformPatches), nameof(SkipPrefix))
         );
+
+        // Android 16 uses extended locale identifiers with Unicode extensions
+        // (e.g. "de-DE-u-mu-celsius") which .NET's CultureInfo cannot parse,
+        // crashing the localization system and preventing the game from loading.
+        PatchGetThreeLetterLanguageCode(harmony);
     }
 
     public static bool InitializePlatformPrefix(ref Task<bool> __result)
@@ -74,5 +82,74 @@ public static class PlatformPatches
         if (!fullPath.Contains("://"))
             return false;
         return true;
+    }
+
+    private static void PatchGetThreeLetterLanguageCode(Harmony harmony)
+    {
+        try
+        {
+            var sts2Asm = typeof(NGame).Assembly;
+            var nullStrategyType = sts2Asm.GetType(
+                "MegaCrit.Sts2.Core.Platform.Null.NullPlatformUtilStrategy"
+            );
+            if (nullStrategyType == null)
+            {
+                PatchHelper.Log("Locale fix: NullPlatformUtilStrategy not found, skipping");
+                return;
+            }
+
+            var method = nullStrategyType.GetMethod(
+                "GetThreeLetterLanguageCode",
+                BindingFlags.Public | BindingFlags.Instance
+            );
+            if (method == null)
+            {
+                PatchHelper.Log("Locale fix: GetThreeLetterLanguageCode not found, skipping");
+                return;
+            }
+
+            harmony.Patch(
+                method,
+                prefix: new HarmonyMethod(
+                    typeof(PlatformPatches).GetMethod(
+                        nameof(GetThreeLetterLanguageCodePrefix),
+                        BindingFlags.Public | BindingFlags.Static
+                    )
+                )
+            );
+            PatchHelper.Log("Patched NullPlatformUtilStrategy.GetThreeLetterLanguageCode (locale fix)");
+        }
+        catch (Exception ex)
+        {
+            PatchHelper.Log($"Locale fix failed: {ex.Message}");
+        }
+    }
+
+    // Strip Unicode extension subtags (e.g. "-u-mu-celsius") from the locale
+    // string before passing it to CultureInfo, which doesn't understand them.
+    public static bool GetThreeLetterLanguageCodePrefix(ref string __result)
+    {
+        try
+        {
+            var locale = Godot.OS.GetLocale(); // e.g. "de_DE_u_mu_celsius" or "de_DE"
+            var sanitized = StripUnicodeExtensions(locale.Replace('_', '-'));
+            PatchHelper.Log($"Locale fix: raw='{locale}' sanitized='{sanitized}'");
+            var culture = new CultureInfo(sanitized);
+            __result = culture.ThreeLetterISOLanguageName;
+        }
+        catch (Exception ex)
+        {
+            PatchHelper.Log($"Locale fix: fallback to 'eng' due to: {ex.Message}");
+            __result = "eng";
+        }
+        return false;
+    }
+
+    // Strips Unicode BCP 47 extension subtags: everything from "-u-" onward.
+    // "de-DE-u-mu-celsius" → "de-DE", "en-US" → "en-US"
+    private static string StripUnicodeExtensions(string locale)
+    {
+        var idx = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
+        return idx >= 0 ? locale.Substring(0, idx) : locale;
     }
 }


### PR DESCRIPTION
## Summary

- **Fixes #27, fixes #11** — game shows black screen on devices with non-default regional preferences (e.g. temperature set to Celsius, metric units)
- When regional preferences are customized, Android appends Unicode BCP 47 extensions to locale strings (e.g. `en-US-u-mu-celsius`, `de-DE-u-ms-metric-mu-celsius`). .NET's `CultureInfo` cannot parse these, causing `LocManager` to fail during startup, which cascades into `NullReferenceException`s in font substitution, localized strings, and static initializers (`AssetSets`, `NPotionHolder`), ultimately preventing the game from loading past a black screen.
- Patches `NullPlatformUtilStrategy.GetThreeLetterLanguageCode()` to strip BCP 47 Unicode extension subtags before passing the locale to `CultureInfo`. Falls back to `"eng"` if parsing still fails.

## Root cause

```
System.Globalization.CultureNotFoundException: Culture is not supported.
de-DE-#u-mu-celsius is an invalid culture identifier.
   at NullPlatformUtilStrategy.GetThreeLetterLanguageCode()
   at LocManager..ctor()
   at OneTimeInitialization.ExecuteEssential()
```

This affects any Android device where regional preferences have been customized (temperature, measurement units, etc.) — most commonly Pixel devices, but potentially any OEM. Credit to @pjmore for independently identifying the same root cause in #11.

## Test plan

- [x] Verified on Pixel 10 Pro (Android 16, locale `de-DE-u-mu-celsius`) — black screen before fix, loads and runs after
- [x] Confirmed the extensions are appended regardless of language choice (tested `de-DE` and `en-US`)
- [x] Verified Xiaomi Pad Mini (Android 16, no regional customizations, locale `de-DE`) is unaffected
- [ ] Test on device with default regional preferences to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)