### PR TITLE
Fix post-update blackscreen: swallow font NRE, unbreak ModLoaderPatches

### DIFF
--- a/src/STS2Mobile/ModEntry.cs
+++ b/src/STS2Mobile/ModEntry.cs
@@ -64,6 +64,7 @@ public static class ModEntry
             ModelDbInitPatch.Apply(_harmony);
             PlatformPatches.Apply(_harmony);
             SettingsPatches.Apply(_harmony);
+            FontSubstitutionPatches.Apply(_harmony);
             UiScalePatches.Apply(_harmony);
             MobileLayoutPatches.Apply(_harmony);
             EventLayoutPatches.Apply(_harmony);

--- a/src/STS2Mobile/Patches/FontSubstitutionPatches.cs
+++ b/src/STS2Mobile/Patches/FontSubstitutionPatches.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes;
+
+namespace STS2Mobile.Patches;
+
+// Post-game-update workaround: the game's
+// MegaCrit.Sts2.Core.Localization.Fonts.FontControlUtils.ApplyLocaleFontSubstitution
+// started throwing NullReferenceException on mobile after a recent StS2
+// update. The exception propagates out of every MegaLabel/NMegaTextEdit
+// _Ready(), which leaves the entire UI uninitialized and produces the
+// "post-update blackscreen" symptom.
+//
+// We install a Harmony finalizer that swallows the exception. Labels
+// miss their locale-specific font override but fall back to the theme
+// default, so the menu renders with readable (if not pixel-perfect)
+// text and the game becomes playable again.
+public static class FontSubstitutionPatches
+{
+    private static bool _loggedFirstSwallow;
+
+    public static void Apply(Harmony harmony)
+    {
+        var sts2Asm = typeof(NGame).Assembly;
+        var fontUtilsType = sts2Asm.GetType(
+            "MegaCrit.Sts2.Core.Localization.Fonts.FontControlUtils"
+        );
+        if (fontUtilsType == null)
+        {
+            PatchHelper.Log("FontSubstitutionPatches: FontControlUtils type not found; skipping");
+            return;
+        }
+
+        var target = fontUtilsType.GetMethod(
+            "ApplyLocaleFontSubstitution",
+            BindingFlags.Public
+                | BindingFlags.NonPublic
+                | BindingFlags.Static
+                | BindingFlags.Instance
+        );
+        if (target == null)
+        {
+            PatchHelper.Log(
+                "FontSubstitutionPatches: ApplyLocaleFontSubstitution method not found; skipping"
+            );
+            return;
+        }
+
+        try
+        {
+            var finalizer = typeof(FontSubstitutionPatches).GetMethod(
+                nameof(ApplyLocaleFontSubstitutionFinalizer),
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+            harmony.Patch(target, finalizer: new HarmonyMethod(finalizer));
+            PatchHelper.Log("Patched FontControlUtils.ApplyLocaleFontSubstitution (finalizer)");
+        }
+        catch (Exception ex)
+        {
+            PatchHelper.Log($"FontSubstitutionPatches: install failed: {ex.Message}");
+        }
+    }
+
+    // Harmony finalizer signature: returning null suppresses the original
+    // method's exception; returning a non-null Exception replaces it.
+    private static Exception ApplyLocaleFontSubstitutionFinalizer(Exception __exception)
+    {
+        if (__exception == null)
+            return null;
+
+        if (!_loggedFirstSwallow)
+        {
+            _loggedFirstSwallow = true;
+            PatchHelper.Log(
+                $"FontSubstitutionPatches: suppressed {__exception.GetType().Name} "
+                    + $"from ApplyLocaleFontSubstitution (\"{__exception.Message}\"); "
+                    + "further occurrences silenced"
+            );
+        }
+
+        return null;
+    }
+}

--- a/src/STS2Mobile/Patches/ModLoaderPatches.cs
+++ b/src/STS2Mobile/Patches/ModLoaderPatches.cs
@@ -51,15 +51,45 @@ public static class ModLoaderPatches
 
             initializedField.SetValue(null, true);
 
-            // Rebuild _loadedMods to include anything new
+            // Rebuild _loadedMods to include anything new. Resolve Mod.wasLoaded
+            // and ModManager.LoadedMods via reflection: MegaCrit renamed both
+            // post-update (to PascalCase or elsewhere) and we want the build
+            // to survive further renames.
+            const BindingFlags InstFlags =
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
             var modsField = typeof(ModManager).GetField("_mods", AllStatic);
             var loadedModsField = typeof(ModManager).GetField("_loadedMods", AllStatic);
-            var allMods = (List<Mod>)modsField.GetValue(null);
-            loadedModsField.SetValue(null, allMods.Where(m => m.wasLoaded).ToList());
+            var allMods = (System.Collections.IList)modsField.GetValue(null);
 
-            PatchHelper.Log(
-                $"[Mods] External scan complete. Total loaded: {ModManager.LoadedMods.Count}"
-            );
+            MemberInfo wasLoadedMember =
+                (MemberInfo)typeof(Mod).GetField("wasLoaded", InstFlags)
+                ?? typeof(Mod).GetField("WasLoaded", InstFlags)
+                ?? (MemberInfo)typeof(Mod).GetProperty("wasLoaded", InstFlags)
+                ?? typeof(Mod).GetProperty("WasLoaded", InstFlags);
+
+            if (wasLoadedMember == null)
+            {
+                PatchHelper.Log(
+                    "[Mods] Could not locate Mod.wasLoaded field/property; skipping filter."
+                );
+                return;
+            }
+
+            Func<object, bool> isLoaded = wasLoadedMember switch
+            {
+                FieldInfo fi => (m => (bool)fi.GetValue(m)),
+                PropertyInfo pi => (m => (bool)pi.GetValue(m)),
+                _ => (_ => false),
+            };
+
+            var filtered = new List<Mod>();
+            foreach (var mod in allMods)
+                if (isLoaded(mod))
+                    filtered.Add((Mod)mod);
+            loadedModsField.SetValue(null, filtered);
+
+            PatchHelper.Log($"[Mods] External scan complete. Total loaded: {filtered.Count}");
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Been loving this launcher, it's great.

The recent StS2 update broke it for me (and I'm assuming others). launcher opens, dev console visible, but when starting a run, black screen.

`FontControlUtils.ApplyLocaleFontSubstitution` throws a `NullReferenceException` on mobile in the updated game. It's called from every `MegaLabel` / `NMegaTextEdit` in `_Ready()`, so the exception bubbles up out of basically every UI node and nothing renders.

I don't know the real cause inside the game, poss some font asset expected to exist on mobile. But I figured Harmony could just eat the exception. So `Patches/FontSubstitutionPatches.cs` adds a finalizer on that method that returns null (i.e. swallows). Labels lose their locale-specific font override and fall back to the theme default, which looks fine in English and I'd assume passable elsewhere. Menu renders, game is playable, ran a full run on my phone without any other weirdness.

It logs the first swallow with the exception type+message so it's debuggable, then shuts up (there are a LOT of labels).

I know swallowing exceptions is a bit gross. Hopefully you have a cleaner idea.

**`ModLoaderPatches` also breaks**

While building against the new `sts2.dll` I got compile errors on `Mod.wasLoaded` and `ModManager.LoadedMods`. Looks like they were renamed/reshuffled in the update. I swapped both to reflection lookups that try both casings and both field-or-property, so it keeps working now and probably survives the next rename too. If the member genuinely goes away it logs and bails instead of crashing.

Nothing else touched

**Tested**

Samsung device on the current game version. Without this change: launcher → black screen. With, back to normal.

Hope this is useful - thanks again for this project x
