### PR TITLE
fix(mods): adapt ModLoaderPatches to current sts2.dll API

### DIFF
--- a/src/STS2Mobile/Patches/ModLoaderPatches.cs
+++ b/src/STS2Mobile/Patches/ModLoaderPatches.cs
@@ -43,22 +43,39 @@ public static class ModLoaderPatches
 
             PatchHelper.Log($"[Mods] Scanning external mods: {AppPaths.ExternalModsDir}");
 
-            var initializedField = typeof(ModManager).GetField("_initialized", AllStatic);
-            initializedField.SetValue(null, false);
+            // The current sts2.dll API splits mod loading in two:
+            //   ReadModsInDirRecursive(path, source, newMods) — reads manifests
+            //   TryLoadMod(mod)                                — loads a single mod
+            // The previous LoadModsInDirRecursive(DirAccess, ModSource) atomic
+            // call no longer exists, and load state is tracked directly via
+            // Mod.state (ModLoadState enum) instead of a Mod.wasLoaded bool +
+            // ModManager._loadedMods cache.
+            var readMethod = typeof(ModManager).GetMethod("ReadModsInDirRecursive", AllStatic);
+            var newMods = new List<Mod>();
+            readMethod.Invoke(
+                null,
+                new object[] { AppPaths.ExternalModsDir, ModSource.ModsDirectory, newMods }
+            );
 
-            var loadMethod = typeof(ModManager).GetMethod("LoadModsInDirRecursive", AllStatic);
-            loadMethod.Invoke(null, new object[] { dirAccess, ModSource.ModsDirectory });
+            var tryLoadMethod = typeof(ModManager).GetMethod("TryLoadMod", AllStatic);
+            foreach (var mod in newMods)
+            {
+                tryLoadMethod.Invoke(null, new object[] { mod });
+            }
 
-            initializedField.SetValue(null, true);
-
-            // Rebuild _loadedMods to include anything new
+            // Ensure newly loaded mods are visible in ModManager.Mods so the
+            // rest of the game can see them.
             var modsField = typeof(ModManager).GetField("_mods", AllStatic);
-            var loadedModsField = typeof(ModManager).GetField("_loadedMods", AllStatic);
             var allMods = (List<Mod>)modsField.GetValue(null);
-            loadedModsField.SetValue(null, allMods.Where(m => m.wasLoaded).ToList());
+            foreach (var mod in newMods)
+            {
+                if (!allMods.Contains(mod))
+                    allMods.Add(mod);
+            }
 
+            int loadedCount = newMods.Count(m => m.state == ModLoadState.Loaded);
             PatchHelper.Log(
-                $"[Mods] External scan complete. Total loaded: {ModManager.LoadedMods.Count}"
+                $"[Mods] External scan complete. {loadedCount}/{newMods.Count} loaded."
             );
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

The launcher source was written against an older StS2 build, and the current Steam release of `sts2.dll` has refactored several pieces of the modding API. Building `STS2Mobile.csproj` against the shipping DLL fails with `CS1061` / `CS0117`, and even after fixing the build the patch would NRE at runtime because methods it invokes by reflection have been renamed or split.

## API drift

| Old API (current source) | New API (shipping `sts2.dll`) |
|---|---|
| `Mod.wasLoaded` (bool) | `Mod.state` (`ModLoadState` enum: `Loaded` / `Failed` / `Disabled` / …) |
| `ModManager.LoadedMods` (static) | dropped — read `Mod.state` directly |
| `ModManager._loadedMods` (cache field) | dropped — no separate cache |
| `ModManager.LoadModsInDirRecursive(DirAccess, ModSource)` | split into `ReadModsInDirRecursive(string path, ModSource, List<Mod> newMods)` + `TryLoadMod(Mod mod)` |

## Fix

`src/STS2Mobile/Patches/ModLoaderPatches.cs` is updated to:

- Read mod manifests from `AppPaths.ExternalModsDir` into a local list via `ReadModsInDirRecursive`
- Call `TryLoadMod` on each new `Mod`
- Add new mods to `ModManager._mods` so they are visible in `ModManager.Mods` (the rest of the game iterates that list)
- Track the loaded count via `Mod.state == ModLoadState.Loaded`

Diff: +27 / −10 in one file, no other files touched.

## Validation

- `dotnet build -c Release src/STS2Mobile/STS2Mobile.csproj` → 0 warnings, 0 errors against the shipping `sts2.dll`.
- A reflection-based compatibility check covering the new methods/fields and the absence of the old ones — 12/12 checks pass.
- The full mobile APK (with this change applied) was built, installed on a physical Android device, and the launcher reaches the main menu without runtime errors from `ModLoaderPatches`.