### PR TITLE
fix(locale): swallow ApplyLocaleFontSubstitution exception

### DIFF
--- a/src/STS2Mobile/ModEntry.cs
+++ b/src/STS2Mobile/ModEntry.cs
@@ -61,6 +61,7 @@ public static class ModEntry
         // Game patches require sts2.dll; if missing, fall through to standalone launcher.
         try
         {
+            FontSubstitutionPatches.Apply(_harmony);
             ModelDbInitPatch.Apply(_harmony);
             PlatformPatches.Apply(_harmony);
             SettingsPatches.Apply(_harmony);

--- a/src/STS2Mobile/Patches/FontSubstitutionPatches.cs
+++ b/src/STS2Mobile/Patches/FontSubstitutionPatches.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Reflection;
+using System.Threading;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes;
+
+namespace STS2Mobile.Patches;
+
+// Works around a crash in MegaCrit.Sts2.Core.Localization.Fonts.FontControlUtils.
+// ApplyLocaleFontSubstitution() throws a NullReferenceException when the platform
+// locale is non-English (e.g. fr-FR), surfaces through LocString.GetFormattedText
+// during the static .cctor of UI nodes (NTopBarFloorIcon / NPotionHolder), and
+// brings the engine down before the main menu can load — the visible symptom is a
+// hard black screen on launch.
+//
+// Letting the substitution call fail silently lets the engine continue with the
+// default (already-loaded) font set, which renders the affected locales correctly.
+public static class FontSubstitutionPatches
+{
+    private const string TargetTypeName =
+        "MegaCrit.Sts2.Core.Localization.Fonts.FontControlUtils";
+    private const string TargetMethodName = "ApplyLocaleFontSubstitution";
+
+    private static int _suppressionCount;
+
+    public static void Apply(Harmony harmony)
+    {
+        var sts2Asm = typeof(NGame).Assembly;
+        var fontUtilsType = sts2Asm.GetType(TargetTypeName);
+        if (fontUtilsType == null)
+        {
+            PatchHelper.Log(
+                $"FontSubstitution: type {TargetTypeName} not present in sts2.dll; skipping"
+            );
+            return;
+        }
+
+        const BindingFlags methodFlags =
+            BindingFlags.Public
+            | BindingFlags.NonPublic
+            | BindingFlags.Static
+            | BindingFlags.Instance;
+
+        var targetMethod = fontUtilsType.GetMethod(TargetMethodName, methodFlags);
+        if (targetMethod == null)
+        {
+            PatchHelper.Log(
+                $"FontSubstitution: {TargetTypeName}.{TargetMethodName} not found; skipping"
+            );
+            return;
+        }
+
+        var finalizerMethod = typeof(FontSubstitutionPatches).GetMethod(
+            nameof(SwallowFinalizer),
+            BindingFlags.Static | BindingFlags.NonPublic
+        );
+
+        try
+        {
+            harmony.Patch(targetMethod, finalizer: new HarmonyMethod(finalizerMethod));
+            PatchHelper.Log(
+                $"Patched {TargetTypeName}.{TargetMethodName} (finalizer; swallows locale errors)"
+            );
+        }
+        catch (Exception ex)
+        {
+            PatchHelper.Log($"FontSubstitution: failed to install finalizer: {ex.Message}");
+        }
+    }
+
+    // Harmony finalizer convention: returning null marks the original exception
+    // (passed via the special __exception parameter) as handled, so callers see
+    // a normal return instead of an unhandled exception. Returning a non-null
+    // Exception would replace it; returning the same instance would re-throw.
+    private static Exception SwallowFinalizer(Exception __exception)
+    {
+        if (__exception == null)
+        {
+            return null;
+        }
+
+        // Only log the first swallow to avoid spamming on repeated calls.
+        if (Interlocked.Increment(ref _suppressionCount) == 1)
+        {
+            PatchHelper.Log(
+                $"FontSubstitution: suppressed {__exception.GetType().Name} "
+                    + $"from {TargetMethodName} (\"{__exception.Message}\"); "
+                    + "further occurrences will be silenced"
+            );
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

When the platform locale is non-English (reproduced on `fr-FR`), `MegaCrit.Sts2.Core.Localization.Fonts.FontControlUtils.ApplyLocaleFontSubstitution()` throws a `NullReferenceException`. The error gets re-thrown through `LocString.GetFormattedText()` during the static `.cctor` of UI nodes (`NTopBarFloorIcon`, `NPotionHolder`, …). Whether the engine survives the chain of `TypeInitializationException` it produces depends on the host (the launcher itself starts fine; the visible symptom downstream is a hard black screen on first launch on some devices).

## Approach

The bug is inside the shipping `sts2.dll` — the launcher can only work around it via Harmony. The new `FontSubstitutionPatches` adds a finalizer to the buggy method that returns `null`, marking the exception as handled. The substitution call returns without effect, and the engine continues with the default (already-loaded) font set — which renders `fr-FR` (and other affected locales) correctly. The first suppressed exception is logged via `PatchHelper.Log`; subsequent occurrences are silenced to avoid spam.

The patch is fully defensive: if the `FontControlUtils` type or the target method is not present in the linked `sts2.dll`, it logs and skips rather than failing.

## Repro on a non-English Android device (without the patch)

```
E/godot: System.NullReferenceException
   at MegaCrit.Sts2.Core.Localization.LocString.GetFormattedText()
   at MegaCrit.Sts2.Core.HoverTips.HoverTip..ctor(LocString, LocString, Texture2D)
   at MegaCrit.sts2.Core.Nodes.TopBar.NTopBarFloorIcon..cctor()
[…and similar chains for NPotionHolder, NDailyRunScreen, NTopBar*Button…]
```

After the patch: the suppression line shows up once in the log, the engine boots through to the main menu, and gameplay works in `fr-FR`.

## Honest scope note

The exception cascade above is one ingredient in the full black-screen outcome users see — there are other contributing factors (build completeness on the publish side, asset packaging on first run) that I have not isolated. This PR removes one well-defined cause and makes the launcher resilient to it; it does not claim to be the only thing needed.

## Build dependency

Built on top of #56 (ModLoaderPatches API drift fix). Without that PR merged first, the launcher does not compile against the shipping `sts2.dll`, so this patch can't be tested in isolation against current `main`.