### PR TITLE
Fix Android black screens from locale parsing and font substitution failures

### DIFF
--- a/src/STS2Mobile/ModEntry.cs
+++ b/src/STS2Mobile/ModEntry.cs
@@ -64,6 +64,7 @@ public static class ModEntry
             ModelDbInitPatch.Apply(_harmony);
             PlatformPatches.Apply(_harmony);
             SettingsPatches.Apply(_harmony);
+            FontSubstitutionPatches.Apply(_harmony);
             UiScalePatches.Apply(_harmony);
             MobileLayoutPatches.Apply(_harmony);
             EventLayoutPatches.Apply(_harmony);

--- a/src/STS2Mobile/Patches/FontSubstitutionPatches.cs
+++ b/src/STS2Mobile/Patches/FontSubstitutionPatches.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Nodes;
@@ -32,29 +33,35 @@ public static class FontSubstitutionPatches
             return;
         }
 
-        var target = fontUtilsType.GetMethod(
-            "ApplyLocaleFontSubstitution",
-            BindingFlags.Public
-                | BindingFlags.NonPublic
-                | BindingFlags.Static
-                | BindingFlags.Instance
-        );
-        if (target == null)
-        {
-            PatchHelper.Log(
-                "FontSubstitutionPatches: ApplyLocaleFontSubstitution method not found; skipping"
-            );
-            return;
-        }
-
         try
         {
+            var targets = fontUtilsType
+                .GetMethods(
+                    BindingFlags.Public
+                        | BindingFlags.NonPublic
+                        | BindingFlags.Static
+                        | BindingFlags.Instance
+                )
+                .Where(method => method.Name == "ApplyLocaleFontSubstitution")
+                .ToArray();
+            if (targets.Length == 0)
+            {
+                PatchHelper.Log(
+                    "FontSubstitutionPatches: ApplyLocaleFontSubstitution method not found; skipping"
+                );
+                return;
+            }
+
             var finalizer = typeof(FontSubstitutionPatches).GetMethod(
                 nameof(ApplyLocaleFontSubstitutionFinalizer),
                 BindingFlags.NonPublic | BindingFlags.Static
             );
-            harmony.Patch(target, finalizer: new HarmonyMethod(finalizer));
-            PatchHelper.Log("Patched FontControlUtils.ApplyLocaleFontSubstitution (finalizer)");
+            foreach (var target in targets)
+                harmony.Patch(target, finalizer: new HarmonyMethod(finalizer));
+
+            PatchHelper.Log(
+                $"Patched FontControlUtils.ApplyLocaleFontSubstitution ({targets.Length} finalizer target(s))"
+            );
         }
         catch (Exception ex)
         {

--- a/src/STS2Mobile/Patches/FontSubstitutionPatches.cs
+++ b/src/STS2Mobile/Patches/FontSubstitutionPatches.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Reflection;
+using HarmonyLib;
+using MegaCrit.Sts2.Core.Nodes;
+
+namespace STS2Mobile.Patches;
+
+// Post-game-update workaround: the game's
+// MegaCrit.Sts2.Core.Localization.Fonts.FontControlUtils.ApplyLocaleFontSubstitution
+// started throwing NullReferenceException on mobile after a recent StS2
+// update. The exception propagates out of every MegaLabel/NMegaTextEdit
+// _Ready(), which leaves the entire UI uninitialized and produces the
+// "post-update blackscreen" symptom.
+//
+// We install a Harmony finalizer that swallows only that NRE. Labels
+// miss their locale-specific font override but fall back to the theme
+// default, so the menu renders with readable (if not pixel-perfect)
+// text and the game becomes playable again.
+public static class FontSubstitutionPatches
+{
+    private static bool _loggedFirstSwallow;
+
+    public static void Apply(Harmony harmony)
+    {
+        var sts2Asm = typeof(NGame).Assembly;
+        var fontUtilsType = sts2Asm.GetType(
+            "MegaCrit.Sts2.Core.Localization.Fonts.FontControlUtils"
+        );
+        if (fontUtilsType == null)
+        {
+            PatchHelper.Log("FontSubstitutionPatches: FontControlUtils type not found; skipping");
+            return;
+        }
+
+        var target = fontUtilsType.GetMethod(
+            "ApplyLocaleFontSubstitution",
+            BindingFlags.Public
+                | BindingFlags.NonPublic
+                | BindingFlags.Static
+                | BindingFlags.Instance
+        );
+        if (target == null)
+        {
+            PatchHelper.Log(
+                "FontSubstitutionPatches: ApplyLocaleFontSubstitution method not found; skipping"
+            );
+            return;
+        }
+
+        try
+        {
+            var finalizer = typeof(FontSubstitutionPatches).GetMethod(
+                nameof(ApplyLocaleFontSubstitutionFinalizer),
+                BindingFlags.NonPublic | BindingFlags.Static
+            );
+            harmony.Patch(target, finalizer: new HarmonyMethod(finalizer));
+            PatchHelper.Log("Patched FontControlUtils.ApplyLocaleFontSubstitution (finalizer)");
+        }
+        catch (Exception ex)
+        {
+            PatchHelper.Log($"FontSubstitutionPatches: install failed: {ex.Message}");
+        }
+    }
+
+    // Harmony finalizer signature: returning null suppresses the original
+    // method's exception; returning a non-null Exception replaces it.
+    private static Exception ApplyLocaleFontSubstitutionFinalizer(Exception __exception)
+    {
+        if (__exception == null)
+            return null;
+
+        if (__exception is not NullReferenceException)
+            return __exception;
+
+        if (!_loggedFirstSwallow)
+        {
+            _loggedFirstSwallow = true;
+            PatchHelper.Log(
+                $"FontSubstitutionPatches: suppressed {__exception.GetType().Name} "
+                    + $"from ApplyLocaleFontSubstitution (\"{__exception.Message}\"); "
+                    + "further occurrences silenced"
+            );
+        }
+
+        return null;
+    }
+}

--- a/src/STS2Mobile/Patches/PlatformPatches.cs
+++ b/src/STS2Mobile/Patches/PlatformPatches.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Globalization;
+using System.Reflection;
 using System.Threading.Tasks;
 using HarmonyLib;
 using MegaCrit.Sts2.Core.Debug;
@@ -50,6 +53,10 @@ public static class PlatformPatches
             "Initialize",
             prefix: PatchHelper.Method(typeof(PlatformPatches), nameof(SkipPrefix))
         );
+
+        // Android can append Unicode locale extensions for regional preferences
+        // (e.g. "de-DE-u-mu-celsius") which CultureInfo cannot parse here.
+        PatchGetThreeLetterLanguageCode(harmony);
     }
 
     public static bool InitializePlatformPrefix(ref Task<bool> __result)
@@ -74,5 +81,80 @@ public static class PlatformPatches
         if (!fullPath.Contains("://"))
             return false;
         return true;
+    }
+
+    private static void PatchGetThreeLetterLanguageCode(Harmony harmony)
+    {
+        try
+        {
+            var sts2Asm = typeof(NGame).Assembly;
+            var nullStrategyType = sts2Asm.GetType(
+                "MegaCrit.Sts2.Core.Platform.Null.NullPlatformUtilStrategy"
+            );
+            if (nullStrategyType == null)
+            {
+                PatchHelper.Log("Locale fix: NullPlatformUtilStrategy not found, skipping");
+                return;
+            }
+
+            var method = nullStrategyType.GetMethod(
+                "GetThreeLetterLanguageCode",
+                BindingFlags.Public | BindingFlags.Instance
+            );
+            if (method == null)
+            {
+                PatchHelper.Log("Locale fix: GetThreeLetterLanguageCode not found, skipping");
+                return;
+            }
+
+            harmony.Patch(
+                method,
+                prefix: new HarmonyMethod(
+                    typeof(PlatformPatches).GetMethod(
+                        nameof(GetThreeLetterLanguageCodePrefix),
+                        BindingFlags.Public | BindingFlags.Static
+                    )
+                )
+            );
+            PatchHelper.Log("Patched NullPlatformUtilStrategy.GetThreeLetterLanguageCode (locale fix)");
+        }
+        catch (Exception ex)
+        {
+            PatchHelper.Log($"Locale fix failed: {ex.Message}");
+        }
+    }
+
+    // Strip Unicode extension subtags (e.g. "-u-mu-celsius") from the locale
+    // string before passing it to CultureInfo, which doesn't understand them.
+    public static bool GetThreeLetterLanguageCodePrefix(ref string __result)
+    {
+        try
+        {
+            var locale = Godot.OS.GetLocale();
+            var sanitized = StripUnicodeExtensions(locale.Replace('_', '-'));
+            PatchHelper.Log($"Locale fix: raw='{locale}' sanitized='{sanitized}'");
+            var culture = new CultureInfo(sanitized);
+            __result = culture.ThreeLetterISOLanguageName;
+        }
+        catch (Exception ex)
+        {
+            PatchHelper.Log($"Locale fix: fallback to 'eng' due to: {ex.Message}");
+            __result = "eng";
+        }
+        return false;
+    }
+
+    // Strips Unicode extension subtags while preserving the base locale.
+    // Examples: "de-DE-u-mu-celsius" -> "de-DE", "en-US-#u-ms-metric" -> "en-US".
+    private static string StripUnicodeExtensions(string locale)
+    {
+        var unicodeIdx = locale.IndexOf("-u-", StringComparison.OrdinalIgnoreCase);
+        var legacyUnicodeIdx = locale.IndexOf("-#u-", StringComparison.OrdinalIgnoreCase);
+
+        var idx = unicodeIdx;
+        if (idx < 0 || (legacyUnicodeIdx >= 0 && legacyUnicodeIdx < idx))
+            idx = legacyUnicodeIdx;
+
+        return idx >= 0 ? locale.Substring(0, idx) : locale;
     }
 }

--- a/src/STS2Mobile/Patches/PlatformPatches.cs
+++ b/src/STS2Mobile/Patches/PlatformPatches.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Globalization;
 using System.Reflection;
 using System.Threading.Tasks;
 using HarmonyLib;
@@ -56,7 +55,7 @@ public static class PlatformPatches
 
         // Android can append Unicode locale extensions for regional preferences
         // (e.g. "de-DE-u-mu-celsius") which CultureInfo cannot parse here.
-        PatchGetThreeLetterLanguageCode(harmony);
+        PatchGetRawLanguage(harmony);
     }
 
     public static bool InitializePlatformPrefix(ref Task<bool> __result)
@@ -83,7 +82,7 @@ public static class PlatformPatches
         return true;
     }
 
-    private static void PatchGetThreeLetterLanguageCode(Harmony harmony)
+    private static void PatchGetRawLanguage(Harmony harmony)
     {
         try
         {
@@ -98,25 +97,25 @@ public static class PlatformPatches
             }
 
             var method = nullStrategyType.GetMethod(
-                "GetThreeLetterLanguageCode",
-                BindingFlags.Public | BindingFlags.Instance
+                "GetRawLanguage",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance
             );
             if (method == null)
             {
-                PatchHelper.Log("Locale fix: GetThreeLetterLanguageCode not found, skipping");
+                PatchHelper.Log("Locale fix: GetRawLanguage not found, skipping");
                 return;
             }
 
             harmony.Patch(
                 method,
-                prefix: new HarmonyMethod(
+                postfix: new HarmonyMethod(
                     typeof(PlatformPatches).GetMethod(
-                        nameof(GetThreeLetterLanguageCodePrefix),
+                        nameof(GetRawLanguagePostfix),
                         BindingFlags.Public | BindingFlags.Static
                     )
                 )
             );
-            PatchHelper.Log("Patched NullPlatformUtilStrategy.GetThreeLetterLanguageCode (locale fix)");
+            PatchHelper.Log("Patched NullPlatformUtilStrategy.GetRawLanguage (locale fix)");
         }
         catch (Exception ex)
         {
@@ -124,24 +123,22 @@ public static class PlatformPatches
         }
     }
 
-    // Strip Unicode extension subtags (e.g. "-u-mu-celsius") from the locale
-    // string before passing it to CultureInfo, which doesn't understand them.
-    public static bool GetThreeLetterLanguageCodePrefix(ref string __result)
+    // Strip Unicode extension subtags before the game's language-code logic runs.
+    public static void GetRawLanguagePostfix(ref string __result)
     {
-        try
+        var raw = __result;
+        var sanitized = StripUnicodeExtensions(raw?.Replace('_', '-') ?? "");
+        if (string.IsNullOrWhiteSpace(sanitized))
         {
-            var locale = Godot.OS.GetLocale();
-            var sanitized = StripUnicodeExtensions(locale.Replace('_', '-'));
-            PatchHelper.Log($"Locale fix: raw='{locale}' sanitized='{sanitized}'");
-            var culture = new CultureInfo(sanitized);
-            __result = culture.ThreeLetterISOLanguageName;
+            PatchHelper.Log($"Locale fix: raw='{raw}' sanitized empty; using 'en-US'");
+            __result = "en-US";
+            return;
         }
-        catch (Exception ex)
-        {
-            PatchHelper.Log($"Locale fix: fallback to 'eng' due to: {ex.Message}");
-            __result = "eng";
-        }
-        return false;
+
+        if (sanitized != raw)
+            PatchHelper.Log($"Locale fix: raw='{raw}' sanitized='{sanitized}'");
+
+        __result = sanitized;
     }
 
     // Strips Unicode extension subtags while preserving the base locale.


### PR DESCRIPTION
## Summary

- Adapts the Android locale fix path from #38 so `CultureInfo` does not receive Unicode extension locale tails.
- Sanitizes locale output at `NullPlatformUtilStrategy.GetRawLanguage` via postfix, preserving the game�s original `GetThreeLetterLanguageCode` logic for script/region-specific handling.
- Handles both `-u-...` and `-#u-...` extension forms, with `en-US` fallback when the sanitized raw locale is empty or whitespace.
- Adds a guarded font-substitution workaround from #49 for post-update Android startup/UI black-screen failures.
- Patches all `ApplyLocaleFontSubstitution` overloads to avoid `AmbiguousMatchException` if the game DLL exposes multiple matching methods.
- Suppresses only `NullReferenceException` in `ApplyLocaleFontSubstitution`; non-NRE exceptions remain visible.
- Scope intentionally limited to startup black-screen paths. No unrelated launcher, ModLoader, controller, or feature changes.

## Links

- Builds on #38
- Adapts black-screen portion of #49
- Related symptom threads: #11 and #27

## Validation status

- Local `dotnet build src/STS2Mobile/STS2Mobile.csproj` was attempted.
- Build is blocked in this checkout because referenced assemblies are missing under `upstream/godot-export/.godot/mono/publish/arm64/`: `0Harmony`, `GodotSharp`, and `sts2`.
- Maintainer/device runtime validation is requested, especially on Samsung Fold and Android 16 locale-extension repro devices.

## Test plan

- [ ] Build `src/STS2Mobile/STS2Mobile.csproj` in a checkout with the required Godot/StS2 reference assemblies
- [ ] Samsung Fold repro settings: verify Play no longer leaves persistent dev/command overlay or black screen
- [ ] Samsung Android 16 / One UI non-US locale path
- [ ] Pixel Android 16 locale extension path (`-u-...` / `-#u-...`)
- [ ] Default English US locale/regional preferences regression check
- [ ] Confirm no `CultureNotFoundException` at startup
- [ ] Confirm no repeated `ApplyLocaleFontSubstitution` NRE spam